### PR TITLE
Feat/geodjango (#15)

### DIFF
--- a/docs/contents/deploy.rst
+++ b/docs/contents/deploy.rst
@@ -4,34 +4,55 @@ Deploy
 Deploy to Heroku
 ----------------------------------------------------------------------
 
+Script
+------
 
+Run these commands to deploy the project to Heroku:
 
-Create Heroku app::
+.. code-block:: bash
 
-    heroku create <app-name>
+    heroku create --buildpack heroku/python omibus-server-staging
 
-Enable container registry::
+    heroku addons:create heroku-postgresql:essential-0 --app omibus-server-staging
 
-    heroku container:login
+    heroku pg:psql DATABASE_URL -a omibus-server-staging
+    # CREATE EXTENSION postgis;
 
-Enable container registry::
+    heroku addons:create heroku-redis:mini --app omibus-server-staging
+    # Set the broker URL to Redis
+    heroku config:set CELERY_BROKER_URL=`heroku config:get REDIS_URL` --app omibus-server-staging
+    # Scale dyno to 1 instance
+    heroku ps:scale worker=1 -a omibus-server-staging
 
-    docker build -t registry.heroku.com/<app-name>/<process-type> .
+    heroku config:set PYTHONHASHSEED=random -a omibus-server-staging
 
-Make sure to replace `<process-type>` with `web` since this will be for a `web process <https://devcenter.heroku.com/articles/procfile#the-web-process-type>`_.
+    heroku config:set WEB_CONCURRENCY=4 -a omibus-server-staging
 
-Push the image to the registry::
+    heroku config:set DJANGO_DEBUG=False -a omibus-server-staging
+    heroku config:set DJANGO_SETTINGS_MODULE=omibus.settings.production -a omibus-server-staging
+    heroku config:set DJANGO_SECRET_KEY=$(openssl rand -base64 32) -a omibus-server-staging
 
-    docker push registry.heroku.com/<app-name>/<process-type>
+    # Generating a 32 character-long random string without any of the visually similar characters "IOl01":
+    heroku config:set DJANGO_ADMIN_URL="$(openssl rand -base64 4096 | tr -dc 'A-HJ-NP-Za-km-z2-9' | head -c 32)/" -a omibus-server-staging
 
-Release the image to your app::
+    # Set this to your Heroku app url, e.g. 'bionic-beaver-28392.herokuapp.com'
+    heroku config:set DJANGO_ALLOWED_HOSTS=omibus-server-staging-c6d6ea99f779.herokuapp.com -a omibus-server-staging
 
-    heroku container:release <process-type> --app <app-name>
+    # Assign with AWS_ACCESS_KEY_ID
+    heroku config:set DJANGO_AWS_ACCESS_KEY_ID= -a omibus-server-staging
 
-Check the logs::
+    # Assign with AWS_SECRET_ACCESS_KEY
+    heroku config:set DJANGO_AWS_SECRET_ACCESS_KEY= -a omibus-server-staging
 
-    heroku logs --tail
+    # Assign with AWS_STORAGE_BUCKET_NAME
+    heroku config:set DJANGO_AWS_STORAGE_BUCKET_NAME= -a omibus-server-staging
 
-Open the app in your browser::
+    git push heroku dev --app omibus-server-staging
 
-    heroku open
+    heroku run python manage.py createsuperuser --app omibus-server-staging
+
+    heroku run python manage.py check --deploy --app omibus-server-staging
+
+    heroku logs --tail --app omibus-server-staging
+
+    heroku open --app omibus-server-staging


### PR DESCRIPTION
* feat: celery redis and twilio

* lint

* lint

* feat: update CircleCI configuration to use the latest Ubuntu image

* fix: test to use relative imports

* chore: fix tests to path login check code methods

* test_user_can_log_in: mock twilio_client.Client in AuthenticationTest

* chore: update TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_SERVICE_SID environment variables

* chore: update TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_SERVICE_SID environment variables

* feat: geodjango deps and setup with postgis

* feat: Add omibus.planet app and models

The code changes add the `omibus.planet` app and its corresponding models. This includes the `WorldBorder` model with fields for name, area, population, FIPS code, ISO codes, United Nations code, region code, sub-region code, longitude, latitude, and a MultiPolygonField for geometry. The app also includes an admin file, an apps file, migrations, tests, and views.

Recent user commits:
- feat: geodjango deps and setup with postgis
- chore: update TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_SERVICE_SID environment variables
- chore: update TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_SERVICE_SID environment variables
- test_user_can_log_in: mock twilio_client.Client in AuthenticationTest
- chore: fix tests to path login check code methods
- fix: test to use relative imports
- feat: update CircleCI configuration to use the latest Ubuntu image
- lint
- lint
- feat: celery redis and twilio